### PR TITLE
Add support for Logitech G502 Proteus Spectrum and G512 RGB.

### DIFF
--- a/60-openrgb.rules
+++ b/60-openrgb.rules
@@ -128,10 +128,16 @@ SUBSYSTEMS=="usb", ATTR{idVendor}=="0951", ATTR{idProduct}=="16be", TAG+="uacces
 #       Logitech G203 Prodigy                                   #
 #       Logitech G403 Prodigy                                   #
 #       Logitech G403 Hero                                      #
+#       Logitech G502 Proteus Spectrum                          #
+#                                                               #
+#   Keyboards:                                                  #
+#       Logitech G512 RGB                                       #
 #---------------------------------------------------------------#
 SUBSYSTEMS=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="c084", TAG+="uaccess"
 SUBSYSTEMS=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="c083", TAG+="uaccess"
 SUBSYSTEMS=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="c08f", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="c332", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="c33c", TAG+="uaccess"
 
 #---------------------------------------------------------------#
 #  MSI Mysticlight                                              #

--- a/Controllers/LogitechController/LogitechControllerDetect.cpp
+++ b/Controllers/LogitechController/LogitechControllerDetect.cpp
@@ -1,9 +1,11 @@
 #include "LogitechG203Controller.h"
 #include "LogitechG403Controller.h"
+#include "LogitechG502PSController.h"
 #include "LogitechG810Controller.h"
 #include "RGBController.h"
 #include "RGBController_LogitechG203.h"
 #include "RGBController_LogitechG403.h"
+#include "RGBController_LogitechG502PS.h"
 #include "RGBController_LogitechG810.h"
 #include <vector>
 #include <hidapi/hidapi.h>
@@ -18,12 +20,14 @@
 #define LOGITECH_G810_1_PID             0xC337
 #define LOGITECH_G810_2_PID             0xC331
 #define LOGITECH_G512_PID               0xC342
+#define LOGITECH_G512_RGB_PID           0xC33C
 /*-----------------------------------------------------*\
 | Mouse product IDs                                     |
 \*-----------------------------------------------------*/
 #define LOGITECH_G203_PID               0xC084
 #define LOGITECH_G403_PID               0xC083
 #define LOGITECH_G403H_PID              0xC08F
+#define LOGITECH_G502_PS_PID            0xC332
 
 typedef struct
 {
@@ -44,12 +48,14 @@ static const logitech_device device_list[] =
     { LOGITECH_VID,             LOGITECH_G810_1_PID,    1,  DEVICE_TYPE_KEYBOARD,   "Logitech G810 Orion Spectrum"  },
     { LOGITECH_VID,             LOGITECH_G810_2_PID,    1,  DEVICE_TYPE_KEYBOARD,   "Logitech G810 Orion Spectrum"  },
     { LOGITECH_VID,             LOGITECH_G512_PID,      1,  DEVICE_TYPE_KEYBOARD,   "Logitech G512"                 },
+    { LOGITECH_VID,             LOGITECH_G512_RGB_PID,  1,  DEVICE_TYPE_KEYBOARD,   "Logitech G512 RGB"             },
     /*-------------------------------------------------------------------------------------------------------------*\
     | Mice                                                                                                          |
     \*-------------------------------------------------------------------------------------------------------------*/
     { LOGITECH_VID,             LOGITECH_G203_PID,      1,  DEVICE_TYPE_MOUSE,      "Logitech G203 Prodigy"         },
     { LOGITECH_VID,             LOGITECH_G403_PID,      1,  DEVICE_TYPE_MOUSE,      "Logitech G403 Prodigy"         },
     { LOGITECH_VID,             LOGITECH_G403H_PID,     1,  DEVICE_TYPE_MOUSE,      "Logitech G403 Hero"            },
+    { LOGITECH_VID,             LOGITECH_G502_PS_PID,   1,  DEVICE_TYPE_MOUSE,      "Logitech G502 Proteus Spectrum"},
     /*-------------------------------------------------------------------------------------------------------------*\
     | Mousemats                                                                                                     |
     \*-------------------------------------------------------------------------------------------------------------*/
@@ -179,6 +185,13 @@ void DetectLogitechControllers(std::vector<RGBController*>& rgb_controllers)
 
                                     RGBController_LogitechG403* rgb_controller = new RGBController_LogitechG403(controller);
 
+                                    rgb_controller->name = device_list[device_idx].name;
+                                    rgb_controllers.push_back(rgb_controller);
+                                }
+                            case LOGITECH_G502_PS_PID:
+                                {
+                                    LogitechG502PSController* controller = new LogitechG502PSController(dev);
+                                    RGBController_LogitechG502PS* rgb_controller = new RGBController_LogitechG502PS(controller);
                                     rgb_controller->name = device_list[device_idx].name;
                                     rgb_controllers.push_back(rgb_controller);
                                 }

--- a/Controllers/LogitechController/LogitechG502PSController.cpp
+++ b/Controllers/LogitechController/LogitechG502PSController.cpp
@@ -1,0 +1,77 @@
+/*-----------------------------------------*\
+|  Logitech502PSController.cpp              |
+|                                           |
+|  Driver for Logitech G502 Proteus         |
+|  Spectrum mouse lighting controller       |
+|                                           |
+|  kernzerfall 07/28/2020                   |
+\*-----------------------------------------*/
+
+#include "LogitechG502PSController.h"
+
+#include <cstring>
+
+LogitechG502PSController::LogitechG502PSController(hid_device* dev_handle)
+{
+    dev = dev_handle;
+}
+
+LogitechG502PSController::~LogitechG502PSController()
+{
+    hid_close(dev);
+}
+
+void LogitechG502PSController::SendMouseMode
+    (
+    unsigned char       mode,
+    std::uint16_t       speed,
+    unsigned char       channel,
+    unsigned char       red,
+    unsigned char       green,
+    unsigned char       blue
+    )
+{
+    unsigned char usb_buf[20];
+
+    /*-----------------------------------------------------*\
+    | Zero out buffer                                       |
+    \*-----------------------------------------------------*/
+    memset(usb_buf, 0x00, sizeof(usb_buf));
+
+    /*-----------------------------------------------------*\
+    | Set up Lighting Control packet                        |
+    \*-----------------------------------------------------*/
+    usb_buf[0x00]           = 0x11;
+    usb_buf[0x01]           = 0xFF;
+    usb_buf[0x02]           = 0x02;
+    usb_buf[0x03]           = 0x3A;
+    usb_buf[0x04]           = channel;
+
+    usb_buf[0x05]           = mode;
+
+    usb_buf[0x06]           = red;
+    usb_buf[0x07]           = green;
+    usb_buf[0x08]           = blue;
+
+    speed = 1000 + 4750 * (LOGITECH_G502_PS_SPEED_FASTEST - speed);
+    if(mode == LOGITECH_G502_PS_MODE_CYCLE)
+    {
+        usb_buf[0x0B]   = speed >> 8;
+        usb_buf[0x0C]   = speed & 0xFF;
+        usb_buf[0x0D]   = 0x64;
+    }
+    else if(mode == LOGITECH_G502_PS_MODE_BREATHING)
+    {
+        usb_buf[0x09]   = speed >> 8;
+        usb_buf[0x0A]   = speed & 0xFF;
+        usb_buf[0x0C]   = 0x64;
+    }else if(mode == LOGITECH_G502_PS_MODE_STATIC){
+        usb_buf[0x09]   = 0x02;
+    }
+
+    /*-----------------------------------------------------*\
+    | Send packet                                           |
+    \*-----------------------------------------------------*/
+    hid_write(dev, usb_buf, 20);
+    hid_read(dev, usb_buf, 20);
+}

--- a/Controllers/LogitechController/LogitechG502PSController.h
+++ b/Controllers/LogitechController/LogitechG502PSController.h
@@ -1,0 +1,53 @@
+/*-----------------------------------------*\
+|  Logitech502PSController.h                |
+|                                           |
+|  Definitions and types for Logitech       |
+|  G502 Proteus Spectrum mouse lighting     |
+|  controller                               |
+|                                           |
+|  kernzerfall 07/28/2020                   |
+\*-----------------------------------------*/
+
+#include "RGBController.h"
+
+#include <string>
+#include <hidapi/hidapi.h>
+
+#pragma once
+
+enum
+{
+    LOGITECH_G502_PS_MODE_OFF               = 0x00,
+    LOGITECH_G502_PS_MODE_STATIC            = 0x01,
+    LOGITECH_G502_PS_MODE_CYCLE             = 0x03,
+    LOGITECH_G502_PS_MODE_BREATHING         = 0x02
+};
+
+enum
+{
+    LOGITECH_G502_PS_SPEED_SLOWEST          = 0x00, /* Slowest speed                */
+    LOGITECH_G502_PS_SPEED_SLOW             = 0x01, /* Slow speed                   */
+    LOGITECH_G502_PS_SPEED_NORMAL           = 0x02, /* Normal speed                 */
+    LOGITECH_G502_PS_SPEED_FAST             = 0x03, /* Fast speed                   */
+    LOGITECH_G502_PS_SPEED_FASTEST          = 0x04, /* Fastest speed                */
+};
+
+class LogitechG502PSController
+{
+public:
+    LogitechG502PSController(hid_device* dev_handle);
+    ~LogitechG502PSController();
+
+    void        SendMouseMode
+                   (
+                    unsigned char       mode,
+                    unsigned short      speed,
+                    unsigned char       channel,
+                    unsigned char       red,
+                    unsigned char       green,
+                    unsigned char       blue
+                   );
+
+private:
+    hid_device*             dev;
+};

--- a/OpenRGB.pro
+++ b/OpenRGB.pro
@@ -135,6 +135,7 @@ HEADERS +=                                                              \
     Controllers/LEDStripController/LEDStripController.h                 \
     Controllers/LogitechController/LogitechG203Controller.h             \
     Controllers/LogitechController/LogitechG403Controller.h             \
+    Controllers/LogitechController/LogitechG502PSController.h           \
     Controllers/LogitechController/LogitechG810Controller.h             \
     Controllers/MSI3ZoneController/MSI3ZoneController.h                 \
     Controllers/MSIGPUController/MSIGPUController.h                     \
@@ -183,6 +184,7 @@ HEADERS +=                                                              \
     RGBController/RGBController_LEDStrip.h                              \
     RGBController/RGBController_LogitechG203.h                          \
     RGBController/RGBController_LogitechG403.h                          \
+    RGBController/RGBController_LogitechG502PS.h                        \
     RGBController/RGBController_LogitechG810.h                          \
     RGBController/RGBController_MSI3Zone.h                              \
     RGBController/RGBController_MSIGPU.h                                \
@@ -280,6 +282,7 @@ SOURCES +=                                                              \
     Controllers/LogitechController/LogitechControllerDetect.cpp         \
     Controllers/LogitechController/LogitechG203Controller.cpp           \
     Controllers/LogitechController/LogitechG403Controller.cpp           \
+    Controllers/LogitechController/LogitechG502PSController.cpp         \
     Controllers/LogitechController/LogitechG810Controller.cpp           \
     Controllers/MSI3ZoneController/MSI3ZoneController.cpp               \
     Controllers/MSI3ZoneController/MSI3ZoneControllerDetect.cpp         \
@@ -347,6 +350,7 @@ SOURCES +=                                                              \
     RGBController/RGBController_LEDStrip.cpp                            \
     RGBController/RGBController_LogitechG203.cpp                        \
     RGBController/RGBController_LogitechG403.cpp                        \
+    RGBController/RGBController_LogitechG502PS.cpp                      \
     RGBController/RGBController_LogitechG810.cpp                        \
     RGBController/RGBController_MSI3Zone.cpp                            \
     RGBController/RGBController_MSIGPU.cpp                              \

--- a/RGBController/RGBController_LogitechG502PS.cpp
+++ b/RGBController/RGBController_LogitechG502PS.cpp
@@ -1,0 +1,123 @@
+/*-----------------------------------------*\
+|  RGBController_LogitechG403.h             |
+|                                           |
+|  Generic RGB Interface for Logitech G502  |
+|  Proteus Sprectrum Mouse                  |
+|                                           |
+|  kernzerfall 07/28/2020                   |
+\*-----------------------------------------*/
+
+#include "RGBController_LogitechG502PS.h"
+
+RGBController_LogitechG502PS::RGBController_LogitechG502PS(LogitechG502PSController* logitech_ptr)
+{
+    logitech = logitech_ptr;
+
+    name        = "Logitech Mouse Device";
+    type        = DEVICE_TYPE_MOUSE;
+    description = "Logitech Mouse Device";
+
+    mode Static;
+    Static.name       = "Static";
+    Static.value      = LOGITECH_G502_PS_MODE_STATIC;
+    Static.flags      = MODE_FLAG_HAS_PER_LED_COLOR;
+    Static.color_mode = MODE_COLORS_PER_LED;
+    modes.push_back(Static);
+
+    mode Off;
+    Off.name       = "Off";
+    Off.value      = LOGITECH_G502_PS_MODE_OFF;
+    Off.flags      = 0;
+    Off.color_mode = MODE_COLORS_NONE;
+    modes.push_back(Off);
+
+    mode Cycle;
+    Cycle.name       = "Cycle";
+    Cycle.value      = LOGITECH_G502_PS_MODE_CYCLE;
+    Cycle.flags      = MODE_FLAG_HAS_SPEED;
+    Cycle.color_mode = MODE_COLORS_NONE;
+    Cycle.speed_min  = LOGITECH_G502_PS_SPEED_SLOWEST;
+    Cycle.speed_max  = LOGITECH_G502_PS_SPEED_FASTEST;
+    Cycle.speed      = LOGITECH_G502_PS_SPEED_NORMAL;
+    modes.push_back(Cycle);
+
+    mode Breathing;
+    Breathing.name       = "Breathing";
+    Breathing.value      = LOGITECH_G502_PS_MODE_BREATHING;
+    Breathing.flags      = MODE_FLAG_HAS_PER_LED_COLOR | MODE_FLAG_HAS_SPEED;
+    Breathing.color_mode = MODE_COLORS_PER_LED;
+    Breathing.speed_min  = LOGITECH_G502_PS_SPEED_SLOWEST;
+    Breathing.speed_max  = LOGITECH_G502_PS_SPEED_FASTEST;
+    Breathing.speed      = LOGITECH_G502_PS_SPEED_NORMAL;
+    modes.push_back(Breathing);
+
+    SetupZones();
+}
+
+void RGBController_LogitechG502PS::SetupZones()
+{
+    zone G502_PS_side_zone;
+    G502_PS_side_zone.name           = "Mouse Side Zone";
+    G502_PS_side_zone.type           = ZONE_TYPE_SINGLE;
+    G502_PS_side_zone.leds_min       = 1;
+    G502_PS_side_zone.leds_max       = 1;
+    G502_PS_side_zone.leds_count     = 1;
+    G502_PS_side_zone.matrix_map     = NULL;
+    zones.push_back(G502_PS_side_zone);
+
+    led G502_PS_side_led;
+    G502_PS_side_led.name = "Mouse Wheel LED";
+    leds.push_back(G502_PS_side_led);
+
+    zone G502_logo_zone;
+    G502_logo_zone.name           = "Logo Zone";
+    G502_logo_zone.type           = ZONE_TYPE_SINGLE;
+    G502_logo_zone.leds_min       = 1;
+    G502_logo_zone.leds_max       = 1;
+    G502_logo_zone.leds_count     = 1;
+    G502_logo_zone.matrix_map     = NULL;
+    zones.push_back(G502_logo_zone);
+
+    led G502_logo_led;
+    G502_logo_led.name = "Logo LED";
+    leds.push_back(G502_logo_led);
+
+    SetupColors();
+}
+
+void RGBController_LogitechG502PS::ResizeZone(int /*zone*/, int /*new_size*/)
+{
+    /*---------------------------------------------------------*\
+    | This device does not support resizing zones               |
+    \*---------------------------------------------------------*/
+}
+
+void RGBController_LogitechG502PS::DeviceUpdateLEDs()
+{
+    UpdateZoneLEDs(0);
+    UpdateZoneLEDs(1);
+}
+
+void RGBController_LogitechG502PS::UpdateZoneLEDs(int zone)
+{
+    unsigned char red = RGBGetRValue(colors[zone]);
+    unsigned char grn = RGBGetGValue(colors[zone]);
+    unsigned char blu = RGBGetBValue(colors[zone]);
+
+    logitech->SendMouseMode(modes[active_mode].value, modes[active_mode].speed, zone, red, grn, blu);
+}
+
+void RGBController_LogitechG502PS::UpdateSingleLED(int led)
+{
+    UpdateZoneLEDs(led);
+}
+
+void RGBController_LogitechG502PS::SetCustomMode()
+{
+
+}
+
+void RGBController_LogitechG502PS::DeviceUpdateMode()
+{
+    DeviceUpdateLEDs();
+}

--- a/RGBController/RGBController_LogitechG502PS.h
+++ b/RGBController/RGBController_LogitechG502PS.h
@@ -1,0 +1,32 @@
+/*-----------------------------------------*\
+|  RGBController_LogitechG403.h             |
+|                                           |
+|  Generic RGB Interface for Logitech G502  |
+|  Proteus Sprectrum Mouse                  |
+|                                           |
+|  kernzerfall 07/28/2020                   |
+\*-----------------------------------------*/
+
+#pragma once
+#include "RGBController.h"
+#include "LogitechG502PSController.h"
+
+class RGBController_LogitechG502PS : public RGBController
+{
+public:
+    RGBController_LogitechG502PS(LogitechG502PSController* logitech_ptr);
+
+    void        SetupZones();
+
+    void        ResizeZone(int zone, int new_size);
+
+    void        DeviceUpdateLEDs();
+    void        UpdateZoneLEDs(int zone);
+    void        UpdateSingleLED(int led);
+
+    void        SetCustomMode();
+    void        DeviceUpdateMode();
+
+private:
+    LogitechG502PSController*   logitech;
+};


### PR DESCRIPTION
- Set the G512 RGB to use G810 driver
- Add driver and interface for the G502 Proteus Spectrum