### PR TITLE
Add -w / --system-wide option to load/save profiles in /etc/openrgb

### DIFF
--- a/ProfileManager.cpp
+++ b/ProfileManager.cpp
@@ -10,6 +10,7 @@ namespace fs = std::experimental::filesystem;
 
 ProfileManager::ProfileManager(std::vector<RGBController *>& control) : controllers(control)
 {
+    ppath = "./";
     UpdateProfileList();
 }
 
@@ -28,7 +29,7 @@ bool ProfileManager::SaveProfile(std::string profile_name)
         /*---------------------------------------------------------*\
         | Open an output file in binary mode                        |
         \*---------------------------------------------------------*/
-        std::ofstream controller_file(profile_name, std::ios::out | std::ios::binary);
+	std::ofstream controller_file(ppath+profile_name, std::ios::out | std::ios::binary);
 
         /*---------------------------------------------------------*\
         | Write header                                              |
@@ -98,7 +99,7 @@ bool ProfileManager::LoadProfileWithOptions
     /*---------------------------------------------------------*\
     | Open input file in binary mode                            |
     \*---------------------------------------------------------*/
-    std::ifstream controller_file(filename, std::ios::in | std::ios::binary);
+    std::ifstream controller_file(ppath+filename, std::ios::in | std::ios::binary);
 
     /*---------------------------------------------------------*\
     | Read and verify file header                               |
@@ -251,7 +252,7 @@ bool ProfileManager::LoadProfileWithOptions
 
 void ProfileManager::DeleteProfile(std::string profile_name)
 {
-    remove(profile_name.c_str());
+    remove((ppath+profile_name).c_str());
 
     UpdateProfileList();
 }
@@ -263,7 +264,7 @@ void ProfileManager::UpdateProfileList()
     /*---------------------------------------------------------*\
     | Load profiles by looking for .orp files in current dir    |
     \*---------------------------------------------------------*/
-    for(const auto & entry : fs::directory_iterator("."))
+    for(const auto & entry : fs::directory_iterator(ppath))
     {
         std::string filename = entry.path().filename().string();
 
@@ -272,7 +273,7 @@ void ProfileManager::UpdateProfileList()
             /*---------------------------------------------------------*\
             | Open input file in binary mode                            |
             \*---------------------------------------------------------*/
-            std::ifstream profile_file(filename, std::ios::in | std::ios::binary);
+            std::ifstream profile_file(ppath+filename, std::ios::in | std::ios::binary);
 
             /*---------------------------------------------------------*\
             | Read and verify file header                               |

--- a/ProfileManager.h
+++ b/ProfileManager.h
@@ -8,18 +8,19 @@ public:
     ProfileManager(std::vector<RGBController *>& control);
     ~ProfileManager();
 
+    void UpdateProfileList();
     bool SaveProfile(std::string profile_name);
     bool LoadProfile(std::string profile_name);
     bool LoadSizeFromProfile(std::string profile_name);
     void DeleteProfile(std::string profile_name);
 
+    std::string ppath;
     std::vector<std::string> profile_list;
     
 protected:
     std::vector<RGBController *>& controllers;
 
 private:
-    void UpdateProfileList();
     bool LoadProfileWithOptions
             (
             std::string     profile_name,

--- a/ResourceManager.cpp
+++ b/ResourceManager.cpp
@@ -1,5 +1,5 @@
 #include "ResourceManager.h"
-#include "ProfileManager.h"
+#include <iostream>
 
 std::unique_ptr<ResourceManager> ResourceManager::instance;
 
@@ -128,8 +128,6 @@ void ResourceManager::DetectDevicesThreadFunction()
     unsigned int prev_count = 0;
     float        percent = 0.0f;
 
-    ProfileManager profile_manager(rgb_controllers);
-
     /*-------------------------------------------------*\
     | Start at 0% detection progress                    |
     \*-------------------------------------------------*/
@@ -193,9 +191,11 @@ void ResourceManager::DetectDevicesThreadFunction()
         detection_percent = percent * 100.0f;
     }
 
-    profile_manager.LoadSizeFromProfile("sizes.ors");
-    
+    profile_manager->LoadSizeFromProfile("sizes.ors");
+
     DetectDeviceMutex.unlock();
+
+    std::cout << "Device detection done." << std::endl;
 }
 
 void ResourceManager::WaitForDeviceDetection()

--- a/ResourceManager.h
+++ b/ResourceManager.h
@@ -8,6 +8,7 @@
 
 #include "i2c_smbus.h"
 #include "RGBController.h"
+#include "ProfileManager.h"
 
 typedef std::function<void(std::vector<i2c_smbus_interface*>&)>                                 I2CBusDetectorFunction;
 typedef std::function<void(std::vector<RGBController*>&)>                                       DeviceDetectorFunction;
@@ -19,6 +20,7 @@ class ResourceManager
 {
 public:
     static ResourceManager *get();
+    ProfileManager*                             profile_manager;
     
     ResourceManager();
     ~ResourceManager();

--- a/main.cpp
+++ b/main.cpp
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <thread>
+#include <iostream>
 
 #include "OpenRGBDialog2.h"
 
@@ -27,7 +28,7 @@ std::vector<NetworkClient*> clients;
 /*-------------------------------------------------------------*\
 | Command line functionality and return flags                   |
 \*-------------------------------------------------------------*/
-extern unsigned int cli_main(int argc, char *argv[], std::vector<RGBController *> &rgb_controllers, ProfileManager* profile_manager_in, NetworkServer* network_server_in, std::vector<NetworkClient*> &clients);
+extern unsigned int cli_main(int argc, char *argv[], std::vector<RGBController *> &rgb_controllers, ProfileManager* profile_manager_in, NetworkServer* network_server_in, std::vector<NetworkClient*> &clients, bool ddevs);
 
 enum
 {
@@ -150,11 +151,13 @@ int main(int argc, char* argv[])
     std::vector<RGBController*> &rgb_controllers = ResourceManager::get()->GetRGBControllers();
 
     ProfileManager profile_manager(rgb_controllers);
+    ResourceManager::get()->profile_manager = &profile_manager;
     NetworkServer server(rgb_controllers);
-    
+   
+    bool ddevs = false;
     if(!AttemptLocalConnection(rgb_controllers))
     {
-        ResourceManager::get()->DetectDevices();
+        ddevs = true;
     }
 
     /*---------------------------------------------------------*\
@@ -163,7 +166,7 @@ int main(int argc, char* argv[])
     unsigned int ret_flags = RET_FLAG_START_GUI;
     if(argc > 1)
     {
-        ret_flags = cli_main(argc, argv, rgb_controllers, &profile_manager, &server, clients);
+        ret_flags = cli_main(argc, argv, rgb_controllers, &profile_manager, &server, clients, ddevs);
     }
 
     /*---------------------------------------------------------*\
@@ -173,6 +176,8 @@ int main(int argc, char* argv[])
     \*---------------------------------------------------------*/
     if(ret_flags & RET_FLAG_START_GUI)
     {
+        if (ddevs) ResourceManager::get()->DetectDevices();
+
         QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
         QApplication a(argc, argv);
 
@@ -203,7 +208,7 @@ int main(int argc, char* argv[])
         {
             dlg.show();
         }
-        
+
         return a.exec();
     }
     else


### PR DESCRIPTION
A quick and dirty answer to [issue 463 at gitlab](https://gitlab.com/CalcProgrammer1/OpenRGB/-/issues/463).  I tried to register at gitlab with no luck, so here we are.

Not a complete and clean solution as requested by the issue author, but allows me to load "openrgb -w --server" at boot using a very simple openrc init script, then set the desired profiles using the qt UI (or the python client).

The path "/etc/openrgb/" is hardcoded in cli.cpp::cli_main(...). The function now has a new parameter 'bool ddevs' to instruct the function to detect devices if there's the need of.

I had to change a few more lines in order to make it work properly: 

1) ResourceManager::DetectDevicesThreadFunction had its own ProfileManager instance and this prevented the profiles to work properly. Probably a pre-existing bug. Anyway, now there's a ProfileManager pointer in the ResourceManager class and the pointer is initialized right after the ProfileManager init in main.cpp. In this way LoadSizeFromProfile("sizes.ors") uses a common ProfileManager object. When I was preparing the patch I noticed a static ProfileManager, probably I should have used that from ResourceManager instead of adding a new pointer to ResourceManager class... 

2) There are 2 calls to ResourceManager::get()->DetectDevices() instead of one only at the beginning of main.cpp. One call is in cli.cpp (in case no gui has been requested). The other call is main.cpp still, but moved after the call to cli_main(...) because command-line options must be parsed in order to activate the new 'system wide mode'; and parsing occurs in cli_main. Moreover the devices detection must occur after the new ProfileManager::ppath string has been filled with the right path and this, again, happens in cli_main.

I tested what I needed but can't say anything about other use cases: --server works, --gui works, if none of the two are passed (ie: -w switch only) just makes the program to exit.
