### PR TITLE
added compatibility with M602 Griffin

### DIFF
--- a/Controllers/RedragonController/RedragonControllerDetect.cpp
+++ b/Controllers/RedragonController/RedragonControllerDetect.cpp
@@ -14,6 +14,7 @@
 #define REDRAGON_M715_PID               0xFC39
 #define REDRAGON_M716_PID               0xFC3A
 #define REDRAGON_M908_PID               0xFC4D
+#define REDRAGON_M602_PID               0xFC38
 
 /******************************************************************************************\
 *                                                                                          *
@@ -42,3 +43,4 @@ REGISTER_HID_DETECTOR_IP("Redragon M711 Cobra",      DetectRedragonMice,      RE
 REGISTER_HID_DETECTOR_IP("Redragon M715 Dagger",     DetectRedragonMice,      REDRAGON_MOUSE_VID,    REDRAGON_M715_PID,         2, REDRAGON_MOUSE_USAGE_PAGE);
 REGISTER_HID_DETECTOR_IP("Redragon M716 Inquisitor", DetectRedragonMice,      REDRAGON_MOUSE_VID,    REDRAGON_M716_PID,         2, REDRAGON_MOUSE_USAGE_PAGE);
 REGISTER_HID_DETECTOR_IP("Redragon M908 Impact",     DetectRedragonMice,      REDRAGON_MOUSE_VID,    REDRAGON_M908_PID,         2, REDRAGON_MOUSE_USAGE_PAGE);
+REGISTER_HID_DETECTOR_IP("Redragon M602 Griffin",    DetectRedragonMice,      REDRAGON_MOUSE_VID,    REDRAGON_M602_PID,         2, REDRAGON_MOUSE_USAGE_PAGE);


### PR DESCRIPTION
The Redragon M602 Griffin works perfectly with controllers, this just adds the ability to connect it to OpenRGB and Control it from there.