### PR TITLE
FreeBSD: Fix compilation

### DIFF
--- a/AutoStart/AutoStart-FreeBSD.cpp
+++ b/AutoStart/AutoStart-FreeBSD.cpp
@@ -4,6 +4,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <limits.h>
 #include <unistd.h>
 #include <sstream>
 
@@ -120,7 +121,7 @@ std::string AutoStart::GetExePath()
     char exepath[ PATH_MAX ];
 
     ssize_t count = readlink("/proc/self/exe", exepath, PATH_MAX);
-    
+
     return(std::string(exepath, (count > 0) ? count : 0));
 }
 
@@ -159,7 +160,7 @@ void AutoStart::InitAutoStart(std::string name)
         std::error_code ec;
 
         bool success = true;
-        
+
         if(!filesystem::exists(autostart_dir))
         {
             success = filesystem::create_directories(autostart_dir, ec);

--- a/Controllers/LenovoControllers/LenovoUSBController.cpp
+++ b/Controllers/LenovoControllers/LenovoUSBController.cpp
@@ -56,7 +56,7 @@ void LenovoUSBController::setZoneLeds(uint8_t zone_num, vector<pair<uint8_t, RGB
 {
     for(size_t curr = 0; curr < led_colors.size();)
     {
-        uint8_t buffer[LENOVO_HID_PACKET_SIZE] = {LENOVO_INSTRUCTION_START, LENOVO_ZONE_ID_0+zone_num, 0, 0};
+        uint8_t buffer[LENOVO_HID_PACKET_SIZE] = {LENOVO_INSTRUCTION_START, static_cast<uint8_t>(LENOVO_ZONE_ID_0+zone_num), 0, 0};
 
         /*---------------------------------------------------------*\
         | Set the colour bytes in the packet                        |
@@ -87,7 +87,7 @@ void LenovoUSBController::setZoneLeds(uint8_t zone_num, vector<pair<uint8_t, RGB
 
 void LenovoUSBController::setSingleLED(uint8_t zone_num, uint8_t led_num, RGBColor color)
 {
-    uint8_t buffer[LENOVO_HID_PACKET_SIZE] = {LENOVO_INSTRUCTION_START, LENOVO_ZONE_ID_0+zone_num, 1, 0, led_num, RGBGetRValue(color), RGBGetGValue(color), RGBGetBValue(color)};
+    uint8_t buffer[LENOVO_HID_PACKET_SIZE] = {LENOVO_INSTRUCTION_START, static_cast<uint8_t>(LENOVO_ZONE_ID_0+zone_num), 1, 0, led_num, static_cast<uint8_t>(RGBGetRValue(color)), static_cast<uint8_t>(RGBGetGValue(color)), static_cast<uint8_t>(RGBGetBValue(color))};
     hid_send_feature_report(dev, buffer, LENOVO_HID_PACKET_SIZE);
 }
 


### PR DESCRIPTION
A couple problems with compiling OpenRGB on FreeBSD:

- A few explicit casts were missing in `Controllers/LenovoControllers/LenovoUSBController.cpp`, which was making Clang complain.
- `limits.h` was not included in `AutoStart/AutoStart-FreeBSD.cpp`, which is supposed to provide the `PATH_MAX` define.