### PR TITLE
Removing conflicting corsair ram detect

### DIFF
--- a/Controllers/CorsairVengeanceController/CorsairVengeanceControllerDetect.cpp
+++ b/Controllers/CorsairVengeanceController/CorsairVengeanceControllerDetect.cpp
@@ -64,17 +64,7 @@ void DetectCorsairVengeanceControllers(std::vector<i2c_smbus_interface*> &busses
                 {
                     CorsairVengeanceController*     new_controller    = new CorsairVengeanceController(busses[bus], addr);
                     RGBController_CorsairVengeance* new_rgbcontroller = new RGBController_CorsairVengeance(new_controller);
-                    
-                    ResourceManager::get()->RegisterRGBController(new_rgbcontroller);
-                }
-            }
-            for(unsigned char addr = 0x18; addr <= 0x1F; addr++)
-            {
-                if(TestForCorsairVengeanceController(busses[bus], addr))
-                {
-                    CorsairVengeanceController*     new_controller    = new CorsairVengeanceController(busses[bus], addr);
-                    RGBController_CorsairVengeance* new_rgbcontroller = new RGBController_CorsairVengeance(new_controller);
-                    
+
                     ResourceManager::get()->RegisterRGBController(new_rgbcontroller);
                 }
             }


### PR DESCRIPTION
A semi recent merge broke dominator platinum integration by using the same look up for vengence sticks. The latter merge should be reverted.

Latter:
https://github.com/CalcProgrammer1/OpenRGB/commit/d6ec41aba4ce4ae7994d6ba5befb2776f412e6d7

Earlier:
https://github.com/CalcProgrammer1/OpenRGB/commit/73d31a17ab2d4b637a5546496c55b7d37b32e148