### PR TITLE
Fix i2c interface detection on Linux

### DIFF
--- a/i2c_smbus/i2c_smbus_linux.cpp
+++ b/i2c_smbus/i2c_smbus_linux.cpp
@@ -59,7 +59,7 @@ s32 i2c_smbus_linux::i2c_xfer(u8 addr, char read_write, int* size, u8* data)
     }
 
     free(msg.buf);
-    
+
     return ret_val;
 }
 
@@ -108,7 +108,7 @@ bool i2c_smbus_linux_detect()
                 if(test_fd)
                 {
                     memset(device_string, 0x00, sizeof(device_string));
-                    
+
                     if(read(test_fd, device_string, sizeof(device_string)) < 0)
                     {
                         LOG_WARNING("[i2c_smbus_linux] Failed to read i2c device name");
@@ -158,7 +158,7 @@ bool i2c_smbus_linux_detect()
                         {
                             LOG_WARNING("[i2c_smbus_linux] Failed to read i2c device PCI vendor ID");
                         }
-                        
+
                         buff[strlen(buff) - 1] = 0x00;
                         pci_vendor = strtoul(buff, NULL, 16);
                         close(test_fd);
@@ -187,7 +187,7 @@ bool i2c_smbus_linux_detect()
                     if (test_fd >= 0)
                     {
                         memset(buff, 0x00, sizeof(buff));
-                        
+
                         if(read(test_fd, buff, sizeof(buff)) < 0)
                         {
                             LOG_WARNING("[i2c_smbus_linux] Failed to read i2c device PCI subvendor ID");
@@ -214,7 +214,7 @@ bool i2c_smbus_linux_detect()
                         pci_subsystem_device = strtoul(buff, NULL, 16);
                         close(test_fd);
                     }
-                    
+
                     strcpy(device_string, "/dev/");
                     strcat(device_string, ent->d_name);
                     test_fd = open(device_string, O_RDWR);

--- a/i2c_smbus/i2c_smbus_linux.cpp
+++ b/i2c_smbus/i2c_smbus_linux.cpp
@@ -94,15 +94,7 @@ bool i2c_smbus_linux_detect()
     }
 
     // Loop through all entries in i2c-adapter list
-    ent = readdir(dir);
-
-    if(ent == NULL)
-    {
-        closedir(dir);
-        return(false);
-    }
-
-    while(ent != NULL)
+    while((ent = readdir(dir)) != NULL)
     {
         if(ent->d_type == DT_DIR || ent->d_type == DT_LNK)
         {
@@ -229,7 +221,6 @@ bool i2c_smbus_linux_detect()
 
                     if (test_fd < 0)
                     {
-                        ent = readdir(dir);
                         ret = false;
                     }
 
@@ -249,7 +240,6 @@ bool i2c_smbus_linux_detect()
                 }
             }
         }
-        ent = readdir(dir);
     }
     closedir(dir);
 


### PR DESCRIPTION
There are cases where detection of an interface fails due to lack of permissions when accessing `/dev/i2c-*`. In some instances, the current code will perform a double `readdir()` and skip what should have been the next interface to be enumerated. Also use this opportunity to clean up a few stray whitespaces.