### PR TITLE
Update issue template with info on how to get verbose log on MacOs

### DIFF
--- a/.gitlab/issue_templates/Bug Report.md
+++ b/.gitlab/issue_templates/Bug Report.md
@@ -13,7 +13,7 @@ and what you expect the correct behavior to be.
 
 ### Attached Log
 <!--
-Please attach a verbose log, you can do it by running the exe from cmd with '--loglevel 6' flag.
+Please attach a verbose log, you can do it by running the exe from cmd with '--loglevel 6' flag or in case of MacOs use the terminal: 'open -a OpenRGB --args --loglevel 6'.
 You can locate them using the Settings tab and click the 'Open Settings Folder' button.
 Important!! Please upload the logs made with the latest pipeline build of OpenRGB.
 -->


### PR DESCRIPTION
The GitLab issue template explains a bit in comment how to run OpenRGB with verbose logging, but on MacOs you can't just call the app path and provide the argument. Added a little hint on how to do that in the comment to encourage providing proper logs with issue reports.