### PR TITLE
Add space for '\0'

### DIFF
--- a/Controllers/PhilipsWizController/PhilipsWizController.cpp
+++ b/Controllers/PhilipsWizController/PhilipsWizController.cpp
@@ -173,7 +173,7 @@ void PhilipsWizController::SetScene(int scene, unsigned char brightness)
 
 void PhilipsWizController::ReceiveThreadFunction()
 {
-    char recv_buf[1024];
+    char recv_buf[1025];
 
     while(ReceiveThreadRun.load())
     {


### PR DESCRIPTION
ReceiveThreadFunction receives max 1024 bytes and then adds '\0' to it, so the buffer needs to be 1025 chars.