### PR TITLE
KingstonFuryDRAMControllerDetect: Additional logging information and refinements

### DIFF
--- a/Controllers/KingstonFuryDRAMController/KingstonFuryDRAMControllerDetect.cpp
+++ b/Controllers/KingstonFuryDRAMController/KingstonFuryDRAMControllerDetect.cpp
@@ -47,8 +47,8 @@ TestResult TestForFurySignature(i2c_smbus_interface *bus, unsigned int slot_addr
     char test_str[] = "FURY";
     int res;
 
-    LOG_DEBUG("[%s] looking at 0x%02X",
-              FURY_CONTROLLER_NAME, slot_addr);
+    LOG_DEBUG("[%s] looking at bus %d address 0x%02X",
+              FURY_CONTROLLER_NAME, bus->bus_id, slot_addr);
 
     // Start transaction
     res = bus->i2c_smbus_write_byte_data(slot_addr, FURY_REG_APPLY, FURY_BEGIN_TRNSFER);
@@ -60,7 +60,7 @@ TestResult TestForFurySignature(i2c_smbus_interface *bus, unsigned int slot_addr
     }
 
     std::this_thread::sleep_for(FURY_DELAY);
-    LOG_DEBUG("[%s] %02X beginning transaction; res=%02X",
+    LOG_DEBUG("[%s] 0x%02X beginning transaction; res=0x%02X",
               FURY_CONTROLLER_NAME, slot_addr, res);
 
     // Read and check the signature
@@ -70,7 +70,7 @@ TestResult TestForFurySignature(i2c_smbus_interface *bus, unsigned int slot_addr
         {
             res = bus->i2c_smbus_read_word_data(slot_addr, i);
             std::this_thread::sleep_for(FURY_DELAY);
-            LOG_DEBUG("[%s] Testing address %02X register %02X, res=%04X",
+            LOG_DEBUG("[%s] Testing address 0x%02X register 0x%02X, res=0x%04X",
                       FURY_CONTROLLER_NAME, slot_addr, i, res);
             // retry when there is an error or the returned value is 0xFFFF
             if((res >= 0) && (res < 0xFFFF))
@@ -84,6 +84,8 @@ TestResult TestForFurySignature(i2c_smbus_interface *bus, unsigned int slot_addr
         }
 
         char shifted = (res >> 8) & 0xFF;
+        LOG_DEBUG("[%s] Matching 0x%02X to 0x%02X: %c",
+                  FURY_CONTROLLER_NAME, shifted, test_str[i-1], test_str[i-1]);
         if(shifted != test_str[i-1])
         {
             passed = false;
@@ -97,13 +99,36 @@ TestResult TestForFurySignature(i2c_smbus_interface *bus, unsigned int slot_addr
         res = bus->i2c_smbus_read_word_data(slot_addr, FURY_REG_MODEL);
         int model_code = res >> 8;
         std::this_thread::sleep_for(FURY_DELAY);
-        LOG_DEBUG("[%s] Reading model code at address %02X register %02X, res=%02X",
+        LOG_DEBUG("[%s] Reading model code at address 0x%02X register 0x%02X, res=0x%02X",
                   FURY_CONTROLLER_NAME, slot_addr, FURY_REG_MODEL, res);
 
         if(!modelChecker(model_code))
         {
             LOG_INFO("[%s] Unknown model code 0x%02X", FURY_CONTROLLER_NAME, model_code);
             passed = false;
+        }
+        else
+        {
+            switch(model_code)
+            {
+                case FURY_MODEL_BEAST_DDR5:
+                    LOG_INFO("[%s] Recognized FURY_MODEL_BEAST_DDR5 at address 0x%02X", FURY_CONTROLLER_NAME, slot_addr);
+                    break;
+                case FURY_MODEL_RENEGADE_DDR5:
+                    LOG_INFO("[%s] Recognized FURY_MODEL_RENEGADE_DDR5 at address 0x%02X", FURY_CONTROLLER_NAME, slot_addr);
+                    break;
+                case FURY_MODEL_BEAST_RGB_WHITE_DDR5:
+                    LOG_INFO("[%s] Recognized FURY_MODEL_BEAST_RGB_WHITE_DDR5 at address 0x%02X", FURY_CONTROLLER_NAME, slot_addr);
+                    break;
+                case FURY_MODEL_BEAST_WHITE_DDR4:
+                    LOG_INFO("[%s] Recognized FURY_MODEL_BEAST_WHITE_DDR4 at address 0x%02X", FURY_CONTROLLER_NAME, slot_addr);
+                    break;
+                case FURY_MODEL_BEAST_DDR4:
+                    LOG_INFO("[%s] Recognized FURY_MODEL_BEAST_DDR4 at address 0x%02X", FURY_CONTROLLER_NAME, slot_addr);
+                    break;
+                default:
+                    break;
+            }
         }
     }
 
@@ -114,7 +139,7 @@ TestResult TestForFurySignature(i2c_smbus_interface *bus, unsigned int slot_addr
         return RESULT_ERROR;
     }
     std::this_thread::sleep_for(FURY_DELAY);
-    LOG_DEBUG("[%s] %02X ending transaction; res=%02X",
+    LOG_DEBUG("[%s] 0x%02X ending transaction; res=0x%02X",
               FURY_CONTROLLER_NAME, slot_addr, res);
 
     return passed ? RESULT_PASS : RESULT_FAIL;
@@ -148,9 +173,14 @@ void DetectKingstonFuryDRAMControllers(i2c_smbus_interface* bus, std::vector<SPD
         // RAM module successfully detected in the slot 'slot_index'
         if(result == RESULT_PASS)
         {
-            LOG_DEBUG("[%s] detected at slot index %d",
+            LOG_DEBUG("[%s] detected at slot index 0x%02x",
                       FURY_CONTROLLER_NAME, slot->index());
             fury_slots.push_back(slot->index());
+        }
+        else
+        {
+            LOG_DEBUG("[%s] not detected at slot index 0x%02x",
+                      FURY_CONTROLLER_NAME, slot->index());
         }
     }
 }


### PR DESCRIPTION
I have a brand new computer including Kingston Fury RAM with LED lighting: KF560C36-32
I was digging into OpenRGB to see why it's detecting one stick of RAM, but not the other.
I can set both to a specified colour with the attached script, included here mainly for my reference.

I did not root-cause why OpenRGB is unhappy with my setup.
But along the way I did make some changes to the logging for TestForFurySignature that might be acceptable.

The output on my machine is:
```
[Kingston Fury DDR4 DRAM] Detector 1 Jedec ID: 0x0117
[Kingston Fury DDR5 DRAM] Detector 2 Jedec ID: 0x0117
[Kingston Fury DDR5 DRAM] is enabled
[ResourceManager] Calling detection progress callbacks.
[Kingston Fury DDR4/5 DRAM] looking at bus 0 address 0x61
[Kingston Fury DDR4/5 DRAM] 0x61 beginning transaction; res=0x00
[Kingston Fury DDR4/5 DRAM] Testing address 0x61 register 0x01, res=0x0708
[Kingston Fury DDR4/5 DRAM] Matching 0x07 to 0x46: F
[Kingston Fury DDR4/5 DRAM] 0x61 ending transaction; res=0x00
[Kingston Fury DDR4/5 DRAM] not detected at slot index 0x01
[Kingston Fury DDR4/5 DRAM] looking at bus 0 address 0x63
[Kingston Fury DDR4/5 DRAM] 0x63 beginning transaction; res=0x00
[Kingston Fury DDR4/5 DRAM] Testing address 0x63 register 0x01, res=0xFFFF
[Kingston Fury DDR4/5 DRAM] Testing address 0x63 register 0x01, res=0x465A
[Kingston Fury DDR4/5 DRAM] Matching 0x46 to 0x46: F
[Kingston Fury DDR4/5 DRAM] Testing address 0x63 register 0x02, res=0x555A
[Kingston Fury DDR4/5 DRAM] Matching 0x55 to 0x55: U
[Kingston Fury DDR4/5 DRAM] Testing address 0x63 register 0x03, res=0x525A
[Kingston Fury DDR4/5 DRAM] Matching 0x52 to 0x52: R
[Kingston Fury DDR4/5 DRAM] Testing address 0x63 register 0x04, res=0x595A
[Kingston Fury DDR4/5 DRAM] Matching 0x59 to 0x59: Y
[Kingston Fury DDR4/5 DRAM] Reading model code at address 0x63 register 0x06, res=0x105A
[Kingston Fury DDR4/5 DRAM] Recognized FURY_MODEL_BEAST_DDR5 at address 0x63
[Kingston Fury DDR4/5 DRAM] 0x63 ending transaction; res=0x00
[Kingston Fury DDR4/5 DRAM] detected at slot index 0x03
[Kingston Fury DDR5 RGB] Registering RGB controller
```

My best guess is that `0x61` needs some sort of _poke_ to respond with FURY.

Additional information:
```
Handle 0x0018, DMI type 17, 92 bytes
Memory Device
        Array Handle: 0x0013
        Error Information Handle: 0x0017
        Total Width: 64 bits
        Data Width: 64 bits
        Size: 32 GB
        Form Factor: DIMM
        Set: None
        Locator: DIMM 1
        Bank Locator: P0 CHANNEL A
        Type: DDR5
        Type Detail: Synchronous Unbuffered (Unregistered)
        Speed: 4800 MT/s
        Manufacturer: Kingston
        Serial Number: 38032A59
        Asset Tag: Not Specified
        Part Number: KF560C36-32                   
        Rank: 2
        Configured Memory Speed: 4800 MT/s
        Minimum Voltage: 1.1 V
        Maximum Voltage: 1.1 V
        Configured Voltage: 1.1 V
        Memory Technology: DRAM
        Memory Operating Mode Capability: Volatile memory
        Firmware Version: Unknown
        Module Manufacturer ID: Bank 2, Hex 0x98
        Module Product ID: Unknown
        Memory Subsystem Controller Manufacturer ID: Unknown
        Memory Subsystem Controller Product ID: Unknown
        Non-Volatile Size: None
        Volatile Size: 32 GB
        Cache Size: None
        Logical Size: None
```

```
$ i2cdetect -l
i2c-0	smbus     	SMBus PIIX4 adapter port 0 at 0b00	SMBus adapter
i2c-1	smbus     	SMBus PIIX4 adapter port 2 at 0b00	SMBus adapter
i2c-2	smbus     	SMBus PIIX4 adapter port 1 at 0b20	SMBus adapter
i2c-3	i2c       	AMDGPU DM i2c hw bus 0          	I2C adapter
i2c-4	i2c       	AMDGPU DM i2c hw bus 1          	I2C adapter
i2c-5	i2c       	AMDGPU DM i2c hw bus 2          	I2C adapter
i2c-6	i2c       	NVIDIA i2c adapter 1 at 1:00.0  	I2C adapter
i2c-7	i2c       	NVIDIA i2c adapter 3 at 1:00.0  	I2C adapter
i2c-8	i2c       	NVIDIA i2c adapter 4 at 1:00.0  	I2C adapter
i2c-9	i2c       	NVIDIA i2c adapter 5 at 1:00.0  	I2C adapter
i2c-10	i2c       	NVIDIA i2c adapter 6 at 1:00.0  	I2C adapter
i2c-11	i2c       	AMDGPU DM aux hw bus 1          	I2C adapter
i2c-12	i2c       	AMDGPU DM aux hw bus 2          	I2C adapter
```

```
#!/bin/bash

bus=0
ram1addr=0x61
ram2addr=0x63

if ! [[ $1 =~ ^0x[0-9a-fA-F]{2}$ ]]; then
    echo "$1 is not a valid octet hex value"
    exit 1
fi
red=$1

if ! [[ $2 =~ ^0x[0-9a-fA-F]{2}$ ]]; then
    echo "$2 is not a valid octet hex value"
    exit 1
fi
green=$2

if ! [[ $3 =~ ^0x[0-9a-fA-F]{2}$ ]]; then
    echo "$3 is not a valid octet hex value"
    exit 1
fi
blue=$3

echo "Setting static R=$red G=$green B=$blue"

i2cset -y $bus $ram1addr 0x08 0x53
sleep 0.020
i2cset -y $bus  $ram1addr 0x09 0x00
sleep 0.020
i2cset -y $bus  $ram1addr 0x31 $red
sleep 0.020
i2cset -y $bus  $ram1addr 0x32 $green
sleep 0.020
i2cset -y $bus  $ram1addr 0x33 $blue
sleep 0.020
i2cset -y $bus  $ram1addr 0x20 0x1e
sleep 0.020
i2cset -y $bus  $ram1addr 0x08 0x44

sleep 0.020
i2cset -y $bus  $ram2addr 0x08 0x53
sleep 0.020
i2cset -y $bus  $ram2addr 0x09 0x00
sleep 0.020
i2cset -y $bus  $ram2addr 0x31 $red
sleep 0.020
i2cset -y $bus  $ram2addr 0x32 $green
sleep 0.020
i2cset -y $bus  $ram2addr 0x33 $blue
sleep 0.020
i2cset -y $bus  $ram2addr 0x20 0x1e
sleep 0.020
i2cset -y $bus  $ram2addr 0x08 0x44
```

