### PR TITLE
Hyperx alloy origins save

### DIFF
--- a/Controllers/HyperXKeyboardController/HyperXAlloyOriginsController/HyperXAlloyOriginsController.h
+++ b/Controllers/HyperXKeyboardController/HyperXAlloyOriginsController/HyperXAlloyOriginsController.h
@@ -23,17 +23,23 @@ public:
 
     std::string     GetDeviceLocation();
     std::string     GetSerialString();
-
-    void SetLEDsDirect(std::vector<RGBColor> colors);
+    void            SaveSettings(std::vector<RGBColor> colors);
+    void            SetLEDsDirect(std::vector<RGBColor> colors);
 
 private:
     hid_device*             dev;
     std::string             location;
 
-    void    SendDirectInitialization();
+    void    write_led_data(std::vector<RGBColor> colors, int memory_loc, int modifier);
+
+    void    SendCommandRaw(unsigned int val1, unsigned int val2, unsigned int val3);
+
+    void    SendDirectInitialization(int memory_loc);
+
+    void    SendDirectFinalization();
+
     void    SendDirectColorPacket
-                (
-                RGBColor*       color_data,
+                (RGBColor*       color_data,
                 unsigned int    color_count
-                );
+                , int modifier);
 };

--- a/Controllers/HyperXKeyboardController/HyperXAlloyOriginsController/RGBController_HyperXAlloyOrigins.cpp
+++ b/Controllers/HyperXKeyboardController/HyperXAlloyOriginsController/RGBController_HyperXAlloyOrigins.cpp
@@ -174,7 +174,7 @@ static const char *led_names[] =
     @name HyperX Alloy Origins
     @category Keyboard
     @type USB
-    @save :x:
+    @save :white_check_mark:
     @direct :white_check_mark:
     @effects :x:
     @detectors DetectHyperXAlloyOrigins
@@ -195,7 +195,7 @@ RGBController_HyperXAlloyOrigins::RGBController_HyperXAlloyOrigins(HyperXAlloyOr
     mode Direct;
     Direct.name       = "Direct";
     Direct.value      = 0xFFFF;
-    Direct.flags      = MODE_FLAG_HAS_PER_LED_COLOR;
+    Direct.flags      = MODE_FLAG_HAS_PER_LED_COLOR | MODE_FLAG_MANUAL_SAVE;
     Direct.color_mode = MODE_COLORS_PER_LED;
     modes.push_back(Direct);
 
@@ -298,6 +298,15 @@ void RGBController_HyperXAlloyOrigins::UpdateSingleLED(int /*led*/)
 void RGBController_HyperXAlloyOrigins::DeviceUpdateMode()
 {
 
+}
+
+void RGBController_HyperXAlloyOrigins::DeviceSaveMode()
+{
+    active_mode = 1;
+    std::this_thread::sleep_for(50ms);;
+    controller->SaveSettings(colors);
+    std::this_thread::sleep_for(50ms);;
+    active_mode = 0;
 }
 
 void RGBController_HyperXAlloyOrigins::KeepaliveThread()

--- a/Controllers/HyperXKeyboardController/HyperXAlloyOriginsController/RGBController_HyperXAlloyOrigins.h
+++ b/Controllers/HyperXKeyboardController/HyperXAlloyOriginsController/RGBController_HyperXAlloyOrigins.h
@@ -30,6 +30,7 @@ public:
     void        UpdateSingleLED(int led);
 
     void        DeviceUpdateMode();
+    void        DeviceSaveMode();
 
     void        KeepaliveThread();
 


### PR DESCRIPTION
Add possibility to save colors to keyboards PRESET_1 button.
Can be extended to save to all 3 buttons -> but your UI has only 1 save button.
So i left the comment in the code -> what parameter maps to which preset button.

Maybe can be extended to other HYPERX products -> but i cannot test as i own only this model.
Fully tested -> saving works fine.