### PR TITLE
Fix high CPU usage on ENE DRAM modules.

### DIFF
--- a/Controllers/ENESMBusController/ENESMBusController.cpp
+++ b/Controllers/ENESMBusController/ENESMBusController.cpp
@@ -425,6 +425,21 @@ void ENESMBusController::SaveMode()
 
 void ENESMBusController::SetAllColorsDirect(RGBColor* colors)
 {
+    auto now = std::chrono::steady_clock::now();
+
+    // Throttle updates
+    if(std::chrono::duration_cast<std::chrono::milliseconds>(now - last_update_time).count() < MIN_UPDATE_MS)
+        return;
+
+    // Skip if colors haven't changed
+    std::vector<RGBColor> current(colors, colors + led_count);
+    if(current == last_colors)
+        return;
+
+    last_colors = current;
+    last_update_time = now;
+
+
     unsigned char* color_buf   = new unsigned char[led_count * 3];
     unsigned int   bytes_sent  = 0;
 
@@ -454,6 +469,20 @@ void ENESMBusController::SetAllColorsDirect(RGBColor* colors)
 
 void ENESMBusController::SetAllColorsEffect(RGBColor* colors)
 {
+    auto now = std::chrono::steady_clock::now();
+
+    // Throttle updates
+    if(std::chrono::duration_cast<std::chrono::milliseconds>(now - last_update_time).count() < MIN_UPDATE_MS)
+        return;
+
+    // Skip if colors haven't changed
+    std::vector<RGBColor> current(colors, colors + led_count);
+    if(current == last_colors)
+        return;
+
+    last_colors = current;
+    last_update_time = now;
+
     unsigned char* color_buf   = new unsigned char[led_count * 3];
     unsigned int   bytes_sent  = 0;
 

--- a/Controllers/ENESMBusController/ENESMBusController.h
+++ b/Controllers/ENESMBusController/ENESMBusController.h
@@ -143,4 +143,8 @@ private:
     bool                    supports_mode_14;
     std::string             name;
     device_type             type;
+
+    std::vector<RGBColor>  LAST_COLOURS;   // log of the previous colors
+    std::chrono::steady_clock::time_point last_update_time;  // previous timestamp
+    static constexpr int  MIN_UPDATE_MS = 50; // capped interval between updates
 };


### PR DESCRIPTION
I don't own the same specs as the issue reporter (GitLab issue #5124). Could anyone check if these changes mitigate the issue. 

This PR addresses the excessive CPU usage observed when controlling ENE-based DRAM RGB modules on Windows. Users reported CPU spikes up to 10% when enabling multiple RAM modules, caused by repeated calls to pawnio_execute during SMBus transfers.