### PR TITLE
Add support for Logitech G522 Gaming Headset

### DIFF
--- a/Controllers/LogitechController/LogitechControllerDetect.cpp
+++ b/Controllers/LogitechController/LogitechControllerDetect.cpp
@@ -14,6 +14,7 @@
 #include "LogitechProtocolCommon.h"
 #include "LogitechG203LController.h"
 #include "LogitechG213Controller.h"
+#include "LogitechG522Controller.h"
 #include "LogitechG560Controller.h"
 #include "LogitechG600Controller.h"
 #include "LogitechG933Controller.h"
@@ -27,6 +28,7 @@
 #include "LogitechX56Controller.h"
 #include "RGBController_LogitechG203L.h"
 #include "RGBController_LogitechG213.h"
+#include "RGBController_LogitechG522.h"
 #include "RGBController_LogitechG560.h"
 #include "RGBController_LogitechG600.h"
 #include "RGBController_LogitechG933.h"
@@ -107,6 +109,7 @@ using namespace std::chrono_literals;
 /*-----------------------------------------------------*\
 | Headset product IDs                                   |
 \*-----------------------------------------------------*/
+#define LOGITECH_G522_PID                           0x0B18
 #define LOGITECH_G633_PID                           0x0A5C
 #define LOGITECH_G635_PID                           0x0A89
 #define LOGITECH_G733_PID                           0x0AB5
@@ -618,6 +621,22 @@ void DetectLogitechG560(hid_device_info* info, const std::string& name)
     }
 }
 
+void DetectLogitechG522(hid_device_info* info, const std::string& name)
+{
+    hid_device* dev = hid_open_path(info->path);
+
+    if(dev)
+    {
+        /*---------------------------------------------*\
+        | Add G522 Headset                              |
+        \*---------------------------------------------*/
+        LogitechG522Controller*     controller     = new LogitechG522Controller(dev, info->path, name);
+        RGBController_LogitechG522* rgb_controller = new RGBController_LogitechG522(controller);
+
+        ResourceManager::get()->RegisterRGBController(rgb_controller);
+    }
+}
+
 void DetectLogitechG933(hid_device_info* info, const std::string& name)
 {
     hid_device* dev = hid_open_path(info->path);
@@ -689,6 +708,7 @@ REGISTER_HID_DETECTOR_IPU("Logitech G560 Lightsync Speaker",                Dete
 /*-------------------------------------------------------------------------------------------------------------------------------------------------*\
 | Headsets                                                                                                                                         |
 \*-------------------------------------------------------------------------------------------------------------------------------------------------*/
+REGISTER_HID_DETECTOR_IPU("Logitech G522 Gaming Headset",                   DetectLogitechG522,         LOGITECH_VID, LOGITECH_G522_PID,                    3, 0xFFA0, 1);
 REGISTER_HID_DETECTOR_IPU("Logitech G933 Lightsync Headset",                DetectLogitechG933,         LOGITECH_VID, LOGITECH_G933_PID,                    3, 0xFF43, 514);
 /*-------------------------------------------------------------------------------------------------------------------------------------------------*\
 | Joysticks                                                                                                                                         |

--- a/Controllers/LogitechController/LogitechG522Controller/LogitechG522Controller.cpp
+++ b/Controllers/LogitechController/LogitechG522Controller/LogitechG522Controller.cpp
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------*\
+| LogitechG522Controller.cpp                                |
+|                                                           |
+|   Driver for Logitech G522 headset                        |
+|                                                           |
+|   fawmdev                                     03 Dec 2024 |
+|                                                           |
+|   This file is part of the OpenRGB project                |
+|   SPDX-License-Identifier: GPL-2.0-or-later               |
+\*---------------------------------------------------------*/
+
+#include <cstring>
+#include "LogitechG522Controller.h"
+
+LogitechG522Controller::LogitechG522Controller(hid_device* dev_handle, const char* path, std::string dev_name)
+{
+    dev         = dev_handle;
+    location    = path;
+    name        = dev_name;
+}
+
+LogitechG522Controller::~LogitechG522Controller()
+{
+    hid_close(dev);
+}
+
+std::string LogitechG522Controller::GetDeviceLocation()
+{
+    return("HID: " + location);
+}
+
+std::string LogitechG522Controller::GetDeviceName()
+{
+    return(name);
+}
+
+void LogitechG522Controller::SetColor(unsigned char red, unsigned char green, unsigned char blue)
+{
+    SendColorPacket(red, green, blue);
+}
+
+void LogitechG522Controller::SetOff()
+{
+    SendColorPacket(0x00, 0x00, 0x00);
+}
+
+void LogitechG522Controller::SendColorPacket(unsigned char red, unsigned char green, unsigned char blue)
+{
+    unsigned char usb_buf[LOGITECH_G522_PACKET_SIZE];
+
+    /*-----------------------------------------------------*\
+    | Zero out buffer                                       |
+    \*-----------------------------------------------------*/
+    memset(usb_buf, 0x00, sizeof(usb_buf));
+
+    /*-----------------------------------------------------*\
+    | Set up Feature Report                                 |
+    | Byte 0: Report ID (0x50)                              |
+    \*-----------------------------------------------------*/
+    usb_buf[0x00] = LOGITECH_G522_REPORT_ID;
+
+    /*-----------------------------------------------------*\
+    | Data header (13 bytes)                                |
+    | Based on reverse engineering of G522 protocol         |
+    \*-----------------------------------------------------*/
+    usb_buf[0x01] = 0x23;
+    usb_buf[0x02] = 0x12;
+    usb_buf[0x03] = 0x00;
+    usb_buf[0x04] = 0x03;
+    usb_buf[0x05] = 0x1A;
+    usb_buf[0x06] = 0x00;
+    usb_buf[0x07] = 0x0D;
+    usb_buf[0x08] = 0x00;
+    usb_buf[0x09] = 0x12;
+    usb_buf[0x0A] = 0x3A;
+    usb_buf[0x0B] = 0x00;
+    usb_buf[0x0C] = 0x00;
+    usb_buf[0x0D] = 0x00;
+
+    /*-----------------------------------------------------*\
+    | Color data (RGB order)                                |
+    \*-----------------------------------------------------*/
+    usb_buf[0x0E] = red;
+    usb_buf[0x0F] = green;
+    usb_buf[0x10] = blue;
+
+    /*-----------------------------------------------------*\
+    | Send Feature Report                                   |
+    \*-----------------------------------------------------*/
+    hid_send_feature_report(dev, usb_buf, LOGITECH_G522_PACKET_SIZE);
+}

--- a/Controllers/LogitechController/LogitechG522Controller/LogitechG522Controller.h
+++ b/Controllers/LogitechController/LogitechG522Controller/LogitechG522Controller.h
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------*\
+| LogitechG522Controller.h                                  |
+|                                                           |
+|   Driver for Logitech G522 headset                        |
+|                                                           |
+|   fawmdev                                     03 Dec 2024 |
+|                                                           |
+|   This file is part of the OpenRGB project                |
+|   SPDX-License-Identifier: GPL-2.0-or-later               |
+\*---------------------------------------------------------*/
+
+#pragma once
+
+#include <string>
+#include <hidapi.h>
+#include "RGBController.h"
+
+/*-----------------------------------------------------*\
+| Logitech G522 Protocol Constants                      |
+\*-----------------------------------------------------*/
+#define LOGITECH_G522_REPORT_ID             0x50
+#define LOGITECH_G522_PACKET_SIZE           65
+
+enum
+{
+    LOGITECH_G522_MODE_OFF                  = 0x00,
+    LOGITECH_G522_MODE_DIRECT               = 0x01,
+};
+
+class LogitechG522Controller
+{
+public:
+    LogitechG522Controller(hid_device* dev_handle, const char* path, std::string dev_name);
+    ~LogitechG522Controller();
+
+    std::string GetDeviceLocation();
+    std::string GetDeviceName();
+
+    void        SetColor(unsigned char red, unsigned char green, unsigned char blue);
+    void        SetOff();
+
+private:
+    hid_device* dev;
+    std::string location;
+    std::string name;
+
+    void        SendColorPacket(unsigned char red, unsigned char green, unsigned char blue);
+};

--- a/Controllers/LogitechController/LogitechG522Controller/RGBController_LogitechG522.cpp
+++ b/Controllers/LogitechController/LogitechG522Controller/RGBController_LogitechG522.cpp
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------*\
+| RGBController_LogitechG522.cpp                            |
+|                                                           |
+|   RGBController for Logitech G522 headset                 |
+|                                                           |
+|   fawmdev                                     03 Dec 2024 |
+|                                                           |
+|   This file is part of the OpenRGB project                |
+|   SPDX-License-Identifier: GPL-2.0-or-later               |
+\*---------------------------------------------------------*/
+
+#include "RGBController_LogitechG522.h"
+
+/**------------------------------------------------------------------*\
+    @name Logitech G522
+    @category Headset
+    @type USB
+    @save :x:
+    @direct :white_check_mark:
+    @effects :x:
+    @detectors DetectLogitechG522
+    @comment
+\*-------------------------------------------------------------------*/
+
+RGBController_LogitechG522::RGBController_LogitechG522(LogitechG522Controller* controller_ptr)
+{
+    controller              = controller_ptr;
+
+    name                    = controller->GetDeviceName();
+    vendor                  = "Logitech";
+    type                    = DEVICE_TYPE_HEADSET;
+    description             = "Logitech G522 Gaming Headset";
+    location                = controller->GetDeviceLocation();
+
+    mode Off;
+    Off.name                = "Off";
+    Off.value               = LOGITECH_G522_MODE_OFF;
+    Off.flags               = 0;
+    Off.color_mode          = MODE_COLORS_NONE;
+    modes.push_back(Off);
+
+    mode Direct;
+    Direct.name             = "Direct";
+    Direct.value            = LOGITECH_G522_MODE_DIRECT;
+    Direct.flags            = MODE_FLAG_HAS_PER_LED_COLOR;
+    Direct.color_mode       = MODE_COLORS_PER_LED;
+    modes.push_back(Direct);
+
+    SetupZones();
+}
+
+void RGBController_LogitechG522::SetupZones()
+{
+    zone G522_zone;
+    G522_zone.name          = "Headset";
+    G522_zone.type          = ZONE_TYPE_SINGLE;
+    G522_zone.leds_min      = 1;
+    G522_zone.leds_max      = 1;
+    G522_zone.leds_count    = 1;
+    G522_zone.matrix_map    = NULL;
+    zones.push_back(G522_zone);
+
+    led G522_led;
+    G522_led.name           = "Headset LED";
+    G522_led.value          = 0x00;
+    leds.push_back(G522_led);
+
+    SetupColors();
+}
+
+void RGBController_LogitechG522::ResizeZone(int /*zone*/, int /*new_size*/)
+{
+    /*---------------------------------------------------------*\
+    | This device does not support resizing zones               |
+    \*---------------------------------------------------------*/
+}
+
+void RGBController_LogitechG522::DeviceUpdateLEDs()
+{
+    unsigned char red = RGBGetRValue(colors[0]);
+    unsigned char grn = RGBGetGValue(colors[0]);
+    unsigned char blu = RGBGetBValue(colors[0]);
+
+    controller->SetColor(red, grn, blu);
+}
+
+void RGBController_LogitechG522::UpdateZoneLEDs(int /*zone*/)
+{
+    DeviceUpdateLEDs();
+}
+
+void RGBController_LogitechG522::UpdateSingleLED(int /*led*/)
+{
+    DeviceUpdateLEDs();
+}
+
+void RGBController_LogitechG522::DeviceUpdateMode()
+{
+    if(modes[active_mode].value == LOGITECH_G522_MODE_OFF)
+    {
+        controller->SetOff();
+    }
+    else
+    {
+        DeviceUpdateLEDs();
+    }
+}

--- a/Controllers/LogitechController/LogitechG522Controller/RGBController_LogitechG522.h
+++ b/Controllers/LogitechController/LogitechG522Controller/RGBController_LogitechG522.h
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------*\
+| RGBController_LogitechG522.h                              |
+|                                                           |
+|   RGBController for Logitech G522 headset                 |
+|                                                           |
+|   fawmdev                                     03 Dec 2024 |
+|                                                           |
+|   This file is part of the OpenRGB project                |
+|   SPDX-License-Identifier: GPL-2.0-or-later               |
+\*---------------------------------------------------------*/
+
+#pragma once
+
+#include "RGBController.h"
+#include "LogitechG522Controller.h"
+
+class RGBController_LogitechG522 : public RGBController
+{
+public:
+    RGBController_LogitechG522(LogitechG522Controller* controller_ptr);
+
+    void        SetupZones();
+
+    void        ResizeZone(int zone, int new_size);
+
+    void        DeviceUpdateLEDs();
+    void        UpdateZoneLEDs(int zone);
+    void        UpdateSingleLED(int led);
+
+    void        DeviceUpdateMode();
+
+private:
+    LogitechG522Controller* controller;
+};


### PR DESCRIPTION
Introduces driver and RGB controller for the Logitech G522 headset, including detection logic, protocol constants, and device registration. This enables OpenRGB to control lighting on the G522 via USB.