### PR TITLE
Add support for msi pro b850 s wifi6 e

### DIFF
--- a/Controllers/MSIMysticLightController/MSIMysticLight761Controller/MSIMysticLight761Controller.cpp
+++ b/Controllers/MSIMysticLightController/MSIMysticLight761Controller/MSIMysticLight761Controller.cpp
@@ -72,7 +72,7 @@ static const mystic_light_761_config board_configs[] =
     { &(board_names[2]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI MPG B850I EDGE TI WIFI
     { &(board_names[3]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI X870 GAMING PLUS WIFI
     { &(board_names[4]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI B850 GAMING PLUS WIFI6E
-    { &(board_names[5]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI B850 GAMING PLUS WIFI6E
+    { &(board_names[5]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI PRO B850-S WIFI6E
     { &(board_names[6]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI B850M GAMING PLUS WIFI6E
     { &(board_names[7]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI MPG X870E CARBON WIFI
     { &(board_names[8]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI Z890 GAMING PLUS WIFI

--- a/Controllers/MSIMysticLightController/MSIMysticLight761Controller/MSIMysticLight761Controller.cpp
+++ b/Controllers/MSIMysticLightController/MSIMysticLight761Controller/MSIMysticLight761Controller.cpp
@@ -52,6 +52,7 @@ static const std::string board_names[] =
     "MSI MPG B850I EDGE TI WIFI (MS-7E79)",
     "MSI X870 GAMING PLUS WIFI (MS-7E47)",
     "MSI B850 GAMING PLUS WIFI6E (MS-7E80)",
+    "MSI PRO B850-S WIFI6E (MS-7E80)",
     "MSI B850M GAMING PLUS WIFI6E (MS-7E81)",
     "MSI MPG X870E CARBON WIFI (MS-7E49)",
     "MSI Z890 GAMING PLUS WIFI (MS-7E34)",
@@ -71,16 +72,17 @@ static const mystic_light_761_config board_configs[] =
     { &(board_names[2]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI MPG B850I EDGE TI WIFI
     { &(board_names[3]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI X870 GAMING PLUS WIFI
     { &(board_names[4]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI B850 GAMING PLUS WIFI6E
-    { &(board_names[5]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI B850M GAMING PLUS WIFI6E
-    { &(board_names[6]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI MPG X870E CARBON WIFI
-    { &(board_names[7]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI Z890 GAMING PLUS WIFI
-    { &(board_names[8]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI X870E GAMING PLUS WIFI
-    { &(board_names[9]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI MAG X870E TOMAHAWK WIFI
-    { &(board_names[10]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },   // MSI PRO B850-P WIFI (MS-7E56)
-    { &(board_names[11]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },   // MSI B850M GAMING PLUS WIFI
-    { &(board_names[12]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },   // MSI PRO X870E-P WIFI
-    { &(board_names[13]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },   // MSI MPG X870I EDGE TI EVO WIFI (MS-7E50)
-    { &(board_names[14]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },   // MSI B850 GAMING PLUS WIFI (MS-7E56)
+    { &(board_names[5]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI B850 GAMING PLUS WIFI6E
+    { &(board_names[6]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI B850M GAMING PLUS WIFI6E
+    { &(board_names[7]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI MPG X870E CARBON WIFI
+    { &(board_names[8]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI Z890 GAMING PLUS WIFI
+    { &(board_names[9]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI X870E GAMING PLUS WIFI
+    { &(board_names[10]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },    // MSI MAG X870E TOMAHAWK WIFI
+    { &(board_names[11]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },   // MSI PRO B850-P WIFI (MS-7E56)
+    { &(board_names[12]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },   // MSI B850M GAMING PLUS WIFI
+    { &(board_names[13]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },   // MSI PRO X870E-P WIFI
+    { &(board_names[14]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },   // MSI MPG X870I EDGE TI EVO WIFI (MS-7E50)
+    { &(board_names[15]), 0,  0,  0, 1, &zone_set1,  MSIMysticLight761Controller::DIRECT_MODE_ZONE_BASED },   // MSI B850 GAMING PLUS WIFI (MS-7E56)
 };
 
 enum MSI_ZONE setup_map [] =


### PR DESCRIPTION
Adds support for the MSI PRO B850-S WIFI6E motherboard. 

This motherboard happens to have the same product name (MS-7E80) as the MSI B850 GAMING PLUS WIFI6E and presumably the exact same chipset. Having compared the two products online it looks like the "GAMING PLUS" version just has cosmetic differences e.g. a different colour scheme, additional heatsinks etc.

I came about making this change as I own the MSI PRO B850-S WIFI6E and noticed that it didn't show up in the 'Devices' list by default after installing OpenRGB even though the product name,  MS-7E80, was in the supported devices list. 

After making this change I've compiled and am currently running this on a MSI PRO B850-S WIFI6E and it seems to be working without issue.

<img width="2295" height="287" alt="Screenshot_20260125_165022" src="https://github.com/user-attachments/assets/2d195309-3937-4a9c-98af-db4eb63f66b4" />
