### PR TITLE
Added support for Kingston Fury "HP" DDR5 Modules.

### DIFF
--- a/Controllers/KingstonFuryDRAMController/KingstonFuryDRAMController.h
+++ b/Controllers/KingstonFuryDRAMController/KingstonFuryDRAMController.h
@@ -41,6 +41,7 @@ enum
     FURY_MODEL_BEAST_DDR5             = 0x10,
     FURY_MODEL_RENEGADE_DDR5          = 0x11,
     FURY_MODEL_BEAST_RGB_WHITE_DDR5   = 0x12,
+    FURY_MODEL_BEAST_HP_DDR5          = 0x13,
     FURY_MODEL_BEAST2_DDR5            = 0x15,
     FURY_MODEL_BEAST_WHITE_DDR4       = 0x21,
     FURY_MODEL_BEAST_DDR4             = 0x23,

--- a/Controllers/KingstonFuryDRAMController/KingstonFuryDRAMControllerDetect.cpp
+++ b/Controllers/KingstonFuryDRAMController/KingstonFuryDRAMControllerDetect.cpp
@@ -38,7 +38,8 @@ bool TestDDR5Models(char code)
     return (code == FURY_MODEL_BEAST_DDR5 ||
             code == FURY_MODEL_BEAST2_DDR5 ||
             code == FURY_MODEL_RENEGADE_DDR5 ||
-            code == FURY_MODEL_BEAST_RGB_WHITE_DDR5);
+            code == FURY_MODEL_BEAST_RGB_WHITE_DDR5 ||
+			code == FURY_MODEL_BEAST_HP_DDR5);
 }
 
 // Checking Fury signature in the RGB address space


### PR DESCRIPTION
I have added this new device ID for DRAM Modules, from Kingston as the one on my new computer were not recognized.
After adding that device I was able to see and configure the DRAM modules properly.